### PR TITLE
Ability to activate and deactivate stampedes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = stampede
 PROJECT_DESCRIPTION = Application resilience testing
-PROJECT_VERSION = 0.4.0
+PROJECT_VERSION = 0.5.0
 
 TEST_DEPS = ct_helper
 dep_ct_helper = git https://github.com/ninenines/ct_helper master

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -21,6 +21,9 @@ ok=application:start(stampede).
 %% Start stampede
 {ok, _}=stampede:start_herd(my_stampede, {application, my_app}).
 
+%% Activate stampede
+ok=stampede:activate(my_stampede).
+
 %% ... Wait and see what happens ...
 
 %% Stop stampede

--- a/doc/src/guide/usage.asciidoc
+++ b/doc/src/guide/usage.asciidoc
@@ -24,7 +24,8 @@ supervisor, that application or supervisor must be running.
 
 === Starting stampedes
 
-Now you can run a stampede on the target application or supervisor.
+Now you can start a stampede on the target application or supervisor.
+To actually start killing anything, the stampede must be activated, see below.
 
 .Start stampeding the `my_app` application
 
@@ -59,6 +60,26 @@ start a stampede for any application you want to target.
 ----
 {ok, _}=stampede:start_herd(my_stampede, {application, my_app}),
 {ok, _}=stampede:start_herd(my_other_stampede, {application, my_other_app}).
+----
+
+=== Activating and deactivating stampedes
+
+After being started, a stamepde is still inactive. This means that the tracer is
+running, keeping track of the processes and ports belonging to the specified
+application or supervisor, but nothing is being killed.
+
+.Activating the `my_stampede` stampede
+
+[source,erlang]
+----
+ok=stampede:activate(my_stampede).
+----
+
+.Deactivate the `my_stampede` stampede
+
+[source,erlang]
+----
+ok=stampede:deactivate(my_stampede).
 ----
 
 === Getting and setting the options of running stampedes

--- a/doc/src/manual/stampede.activate.asciidoc
+++ b/doc/src/manual/stampede.activate.asciidoc
@@ -1,0 +1,30 @@
+= stampede:activate(3)
+
+== Name
+
+stampede:activate - Activate a stampede
+
+== Description
+
+[source,erlang]
+----
+activate(Ref :: ref())
+    -> ok
+----
+
+Activate the specified stampede, ie. start killing processes and ports.
+
+== Arguments
+
+Ref::
+
+The stampede identifier given to `start_herd`.
+
+== Return value
+
+The atom `ok` is always returned.
+
+== See also
+
+link:man:stampede:deactivate(3)[stampede:deactivate(3)]
+link:man:stampede:is_active(3)[stampede:is_active(3)]

--- a/doc/src/manual/stampede.asciidoc
+++ b/doc/src/manual/stampede.asciidoc
@@ -15,6 +15,9 @@ application or supervisor.
 * link:man:stampede:start_herd(3)[stampede:start_herd(3)] - Start a stampede
 * link:man:stampede:stop_herd(3)[stampede:stop_herd(3)] - Stop a stampede
 * link:man:stampede:stop_all(3)[stampede:stop_all(3)] - Stop all stampedes
+* link:man:stampede:activate(3)[stampede:activate(3)] - Activate a stampede
+* link:man:stampede:deactivate(3)[stampede:deactivate(3)] - Deactivate a stampede
+* link:man:stampede:is_active(3)[stampede:is_active(3)] - Check if a stampede is active
 * link:man:stampede:set_opts(3)[stampede:set_opts(3)] - Change the options of a running stampede
 * link:man:stampede:get_opts(3)[stampede:get_opts(3)] - Get the options of a running stampede
 
@@ -66,6 +69,7 @@ or port is allowed.
 * *0.3.0*: Added port killing. `before_kill` callback functions must also
            accept ports now.
 * *0.4.0*: Added ability to retrieve and change the options of running stampedes.
+* *0.5.0*: Added ability to deactivate (pause) and activate (resume) a stampede.
 
 == See also
 

--- a/doc/src/manual/stampede.deactivate.asciidoc
+++ b/doc/src/manual/stampede.deactivate.asciidoc
@@ -1,0 +1,30 @@
+= stampede:deactivate(3)
+
+== Name
+
+stampede:deactivate - Deactivate a stampede
+
+== Description
+
+[source,erlang]
+----
+activate(Ref :: ref())
+    -> ok
+----
+
+Deactivate the specified stampede, ie. stop killing processes and ports.
+
+== Arguments
+
+Ref::
+
+The stampede identifier given to `start_herd`.
+
+== Return value
+
+The atom `ok` is always returned.
+
+== See also
+
+link:man:stampede:activate(3)[stampede:activate(3)]
+link:man:stampede:is_active(3)[stampede:is_active(3)]

--- a/doc/src/manual/stampede.is_active.asciidoc
+++ b/doc/src/manual/stampede.is_active.asciidoc
@@ -1,0 +1,32 @@
+= stampede:is_active(3)
+
+== Name
+
+stampede:is_active - Check if a stampede is active
+
+== Description
+
+[source,erlang]
+----
+is_active(Ref :: ref())
+    -> boolean()
+----
+
+Check if the given stampede is activated or deactivated, ie.
+if it is killing processes and ports or not.
+
+== Arguments
+
+Ref::
+
+The stampede identifier given to `start_herd`.
+
+== Return value
+
+If the given stampede is active, `true` will be returned,
+otherwise `false`.
+
+== See also
+
+link:man:stampede:activate(3)[stampede:activate(3)]
+link:man:stampede:deactivate(3)[stampede:deactivate(3)]

--- a/doc/src/manual/stampede.start_herd.asciidoc
+++ b/doc/src/manual/stampede.start_herd.asciidoc
@@ -8,9 +8,9 @@ stampede:start_herd - Start a stampede
 
 [source,erlang]
 ----
-stampede:start_herd(Ref    :: ref()
-                    Target :: target(),
-                    Opts   :: opts())
+start_herd(Ref    :: ref()
+           Target :: target(),
+           Opts   :: opts())
     -> supervisor:startchild_ret()
 ----
 
@@ -18,12 +18,16 @@ Start stampeding the specified application or supervisor with the given options.
 
 [source,erlang]
 ----
-stampede:start_herd(Ref    :: term(),
-                    Target :: target())
+start_herd(Ref    :: term(),
+           Target :: target())
     -> supervisor:startchild_ret()
 ----
 
 Start stampeding the specified application or supervisor with default options.
+
+The processes and ports belonging to the given application or supervisor will
+only be traced, but not killed  before the stampede is actually activated via
+`stampede:activate/1`.
 
 == Arguments
 
@@ -79,4 +83,5 @@ or is a library application, or if the target supervisor is not running.
 == See also
 
 link:man:stampede:stop_herd(3)[stampede:stop_herd(3)]
+link:man:stampede:activate(3)[stampede:activate(3)]
 link:man:stampede_callbacks(3)[stampede_callbacks(3)]

--- a/doc/src/manual/stampede.stop_herd.asciidoc
+++ b/doc/src/manual/stampede.stop_herd.asciidoc
@@ -30,3 +30,4 @@ An `error` tuple is returned on error, the reason may be any term.
 
 link:man:stampede:stop_all(3)[stampede:stop_all(3)]
 link:man:stampede:start_herd(3)[stampede:start_herd(3)]
+link:man:stampede:deactivate(3)[stampede:deactivate(3)]

--- a/doc/src/manual/stampede_app.asciidoc
+++ b/doc/src/manual/stampede_app.asciidoc
@@ -10,7 +10,9 @@ Stampede is a resilience testing tool for Erlang applications.
 
 When started, stampede will start tracing the target application
 or supervisor in order to keep track of the processes and ports
-belonging to it, and randomly kill those processes and ports
+belonging to it.
+
+When activated, it will randomly kill those processes and ports
 with a definable intensity.
 
 Fine-grained control over what to really kill and what not can
@@ -21,3 +23,5 @@ be achieved with user-defined callbacks.
 * *0.3.0*: Added port killing.
 * *0.4.0*: Added ability to retrieve and change the options of
            running stampedes.
+* *0.5.0*: Added ability to deactivate (pause) and activate
+           (resume) stampedes.

--- a/ebin/stampede.app
+++ b/ebin/stampede.app
@@ -1,6 +1,6 @@
 {application, 'stampede', [
 	{description, "Application resilience testing"},
-	{vsn, "0.4.0"},
+	{vsn, "0.5.0"},
 	{modules, ['stampede','stampede_app','stampede_callbacks','stampede_herd','stampede_herd_sup','stampede_sup','stampede_tracer']},
 	{registered, [stampede_sup]},
 	{applications, [kernel,stdlib]},

--- a/src/stampede.erl
+++ b/src/stampede.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -17,6 +17,9 @@
 -export([start_herd/2, start_herd/3]).
 -export([stop_herd/1]).
 -export([stop_all/0]).
+-export([activate/1]).
+-export([deactivate/1]).
+-export([is_active/1]).
 -export([default_opts/0]).
 -export([set_opts/2]).
 -export([get_opts/1]).
@@ -76,6 +79,18 @@ stop_herd(Ref) ->
 -spec stop_all() -> ok.
 stop_all() ->
 	stampede_sup:stop_all().
+
+-spec activate(ref()) -> ok.
+activate(Ref) ->
+	stampede_sup:activate(Ref).
+
+-spec deactivate(ref()) -> ok.
+deactivate(Ref) ->
+	stampede_sup:deactivate(Ref).
+
+-spec is_active(ref()) -> boolean().
+is_active(Ref) ->
+	stampede_sup:is_active(Ref).
 
 -spec default_opts() -> opts().
 default_opts() ->

--- a/src/stampede_app.erl
+++ b/src/stampede_app.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/stampede_callbacks.erl
+++ b/src/stampede_callbacks.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -128,7 +128,7 @@ if_child1(Pid, Supervisor, Depth) ->
 				Children
 			)
 	catch
-		exit:{noproc, _} ->
+		_:_ ->
 			false
 	end.
 

--- a/src/stampede_herd_sup.erl
+++ b/src/stampede_herd_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -25,7 +25,7 @@ start_link(TopSup, Opts) ->
 	supervisor:start_link(?MODULE, {TopSup, Opts}).
 
 init({TopSup, Opts}) ->
-	Tab = ets:new(?MODULE, []),
+	Tab = ets:new(?MODULE, [public]),
 	{
 		ok,
 		{

--- a/src/stampede_sup.erl
+++ b/src/stampede_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -19,6 +19,9 @@
 -export([start_link/0]).
 -export([start_herd/3]).
 -export([stop_herd/1, stop_all/0]).
+-export([activate/1]).
+-export([deactivate/1]).
+-export([is_active/1]).
 -export([set_opts/2]).
 -export([get_opts/1]).
 -export([init/1]).
@@ -47,6 +50,18 @@ stop_herd(Ref) ->
 stop_all() ->
 	_=[catch supervisor:terminate_child(?MODULE, Id) || {Id={stampede_herd, _}, _, supervisor, _} <- supervisor:which_children(?MODULE)],
 	ok.
+
+-spec activate(stampede:ref()) -> ok.
+activate(Ref) ->
+	stampede_herd:activate(get_herd_pid(Ref)).
+
+-spec deactivate(stampede:ref()) -> ok.
+deactivate(Ref) ->
+	stampede_herd:deactivate(get_herd_pid(Ref)).
+
+-spec is_active(stampede:ref()) -> boolean().
+is_active(Ref) ->
+	stampede_herd:is_active(get_herd_pid(Ref)).
 
 -spec set_opts(stampede:ref(), stampede:opts()) -> ok.
 set_opts(Ref, Opts) ->

--- a/test/callbacks_SUITE.erl
+++ b/test/callbacks_SUITE.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/test/stampede_ct_hook.erl
+++ b/test/stampede_ct_hook.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/test/stampede_test.app
+++ b/test/stampede_test.app
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/test/stampede_test_helper.erl
+++ b/test/stampede_test_helper.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/test/test_app/stampede_test_app.erl
+++ b/test/test_app/stampede_test_app.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/test/test_app/stampede_test_sup.erl
+++ b/test/test_app/stampede_test_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/test/test_app/stampede_test_sup_sup.erl
+++ b/test/test_app/stampede_test_sup_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/test/test_app/stampede_test_wrk.erl
+++ b/test/test_app/stampede_test_wrk.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2019, Jan Uhlig <j.uhlig@mailingwork.de>
+%% Copyright (c) 2020, Jan Uhlig <j.uhlig@mailingwork.de>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Stampedes can be activated and deactivated. When inactive, only the tracer is running to keep track of the processes and ports belonging to the specified application, but no killing will be done.